### PR TITLE
Remove useless options of a2lix_translation_form

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -199,10 +199,3 @@ a2lix_translation_form:
     locales: [en, fr]
     default_required: true
     templating: "OroUIBundle:Form:translateable.html.twig"
-    use_aop: false
-    default_class:
-        service: "A2lix\TranslationFormBundle\TranslationForm\DefaultTranslationForm"
-        listener: "A2lix\TranslationFormBundle\Form\EventListener\DefaultTranslationsSubscriber"
-        types:
-             translations: "A2lix\TranslationFormBundle\Form\Type\TranslationsType"
-             translationsFields: "A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType"


### PR DESCRIPTION
I have refactored a bit the TranslationFormBundle and theses options have been removed.
