### PR TITLE
fixed conflicts with sebastian/phpcpd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "mybuilder/phpunit-accelerator": "1.2.*",
         "squizlabs/php_codesniffer": "2.8.*",
         "phpmd/phpmd": "2.6.*",
-        "sebastian/phpcpd": "dev-master#cff7f36c2ae89d59987de25d14fd41a72dd4a703 as 3.1.0",
+        "sebastian/phpcpd": "3.0.1",
         "phpunit/phpcov": "3.1.*",
         "symfony/phpunit-bridge": "3.2.*",
         "friendsofphp/php-cs-fixer": "2.1.*"


### PR DESCRIPTION
➜  platform-application git:(master) php -d memory_limit=4096 /usr/local/bin/composer update -v --profile 
    1/2:	http://packagist.org/p/provider-latest$92d87f5c39b273345223dc9d941f4c37c812aa5289e808187674e2e5ab5bf028.json
    2/2:	http://packagist.org/p/provider-2018-01$3e8a1343435431d54f9a5d858914f7cdc52fa78f4f95e732d8eb5f7f087cca3b.json
    Finished: success: 2, skipped: 0, failure: 0, total: 2
[6.2MB/0.00s] Loading composer repositories with package information
[6.4MB/1.07s] Updating dependencies (including require-dev)
[2756.1MB/80.18s] Dependency resolution completed in 3.965 seconds
[2756.1MB/80.18s] Your requirements could not be resolved to an installable set of packages.
[2756.1MB/80.19s] 
  Problem 1
    - Installation request for sebastian/phpcpd dev-master#cff7f36c2ae89d59987de25d14fd41a72dd4a703 as 3.1.0 -> satisfiable by sebastian/phpcpd[dev-master].
    - phpunit/phpunit 5.7.0 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.1 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.10 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.11 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.12 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.13 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.14 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.15 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.16 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.17 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.18 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.19 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.2 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.20 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.21 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.22 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.23 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.24 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.25 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.26 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.27 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.3 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.4 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.5 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.6 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.7 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.8 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.9 requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - phpunit/phpunit 5.7.x-dev requires phpunit/php-timer ^1.0.6 -> satisfiable by phpunit/php-timer[1.0.6, 1.0.7, 1.0.8, 1.0.9, 1.0.x-dev].
    - Can only install one of: phpunit/php-timer[2.0.x-dev, 1.0.6].
    - Can only install one of: phpunit/php-timer[2.0.x-dev, 1.0.7].
    - Can only install one of: phpunit/php-timer[2.0.x-dev, 1.0.8].
    - Can only install one of: phpunit/php-timer[2.0.x-dev, 1.0.9].
    - Can only install one of: phpunit/php-timer[2.0.x-dev, 1.0.x-dev].
    - sebastian/phpcpd dev-master requires phpunit/php-timer ^2.0 -> satisfiable by phpunit/php-timer[2.0.0, 2.0.x-dev].
    - Conclusion: don't install phpunit/php-timer 2.0.0
    - Installation request for phpunit/phpunit 5.7.* -> satisfiable by phpunit/phpunit[5.7.0, 5.7.1, 5.7.10, 5.7.11, 5.7.12, 5.7.13, 5.7.14, 5.7.15, 5.7.16, 5.7.17, 5.7.18, 5.7.19, 5.7.2, 5.7.20, 5.7.21, 5.7.22, 5.7.23, 5.7.24, 5.7.25, 5.7.26, 5.7.27, 5.7.3, 5.7.4, 5.7.5, 5.7.6, 5.7.7, 5.7.8, 5.7.9, 5.7.x-dev].
