### PR TITLE
stop breaking build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {"": "src/"},
-        "exclude-from-classmap": ["**/Tests/"],
-        "files": [
-            "vendor/oro/platform/src/Oro/Bundle/LocaleBundle/Intl/Locale.php"
-        ]
+        "exclude-from-classmap": ["**/Tests/"]
     },
     "repositories": {
         "composer": {

--- a/dev.json
+++ b/dev.json
@@ -5,10 +5,7 @@
   "license": "MIT",
   "autoload": {
     "psr-4": {"": "src/"},
-    "exclude-from-classmap": ["**/Tests/"],
-    "files": [
-      "vendor/oro/platform/src/Oro/Bundle/LocaleBundle/Intl/Locale.php"
-    ]
+    "exclude-from-classmap": ["**/Tests/"]
   },
   "repositories": [
     {


### PR DESCRIPTION
composer install won't work because vendor/oro/platform/src/Oro/Bundle/LocaleBundle/Intl/Locale.php is not existing.
`composer install --prefer-dist --no-suggest --optimize-autoloader --no-interaction --ignore-platform-reqs ` 